### PR TITLE
update grpc-netty version

### DIFF
--- a/grpc.md
+++ b/grpc.md
@@ -10,7 +10,7 @@ layout: page
 Install ScalaPB as usual. Add the following to your `build.sbt`:
 
     libraryDependencies ++= Seq(
-        "io.grpc" % "grpc-netty" % "1.0.1",
+        "io.grpc" % "grpc-netty" % "1.0.3",
         "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion
     )
 


### PR DESCRIPTION
ScalaPB 0.5.47 depends on grpc 1.0.3

https://github.com/scalapb/ScalaPB/blob/v0.5.47/build.sbt#L89