### PR TITLE
Clarify customizations in sbt instructions

### DIFF
--- a/index.md
+++ b/index.md
@@ -61,7 +61,7 @@ Add the following line to your `build.sbt`:
       scalapb.gen() -> (sourceManaged in Compile).value
     )
 
-    // If you need scalapb/scalapb.proto or anything from
+    // (optional) If you need scalapb/scalapb.proto or anything from
     // google/protobuf/*.proto
     libraryDependencies += "com.trueaccord.scalapb" %% "scalapb-runtime" % com.trueaccord.scalapb.compiler.Version.scalapbVersion % "protobuf"
 

--- a/sbt-settings.md
+++ b/sbt-settings.md
@@ -23,15 +23,19 @@ Add the following line to your `build.sbt`:
 PB.targets in Compile := Seq(
   scalapb.gen() -> (sourceManaged in Compile).value
 )
-
-// If you need scalapb/scalapb.proto or anything from
-// google/protobuf/*.proto
-libraryDependencies += "com.trueaccord.scalapb" %% "scalapb-runtime" % com.trueaccord.scalapb.compiler.Version.scalapbVersion % "protobuf"
 {% endhighlight %}
 
 Running the `compile` command in sbt will both generate Scala sources from
 your protos and compile them. If you just want to generate Scala sources for
 your protocol buffers without compiling them, run `protoc-generate`
+
+Additionally, if you need [customizations]({{site.baseurl}}/customizations.html) from
+scalapb/scalapb.proto or anything from `google/protobuf/*.proto`, add the
+following to your `build.sbt`:
+
+{% highlight scala %}
+libraryDependencies += "com.trueaccord.scalapb" %% "scalapb-runtime" % com.trueaccord.scalapb.compiler.Version.scalapbVersion % "protobuf"
+{% endhighlight %}
 
 ## Defaults
 


### PR DESCRIPTION
Thank you for a great project and great docs! When setting up scalapb in scala.meta (http://scalameta.org/, https://github.com/scalameta/scalameta/pull/748), I blindly copied everything from the "Add the following..." code listing into our build.sbt. However, I found out later that those lines added 10mb to our fat jar (https://github.com/scalameta/scalameta/pull/760). This PR is just a small change to highlight that those lines are optional.