### PR TITLE
Add missing ; to custom collection example

### DIFF
--- a/customizations.md
+++ b/customizations.md
@@ -284,7 +284,7 @@ import "scalapb/scalapb.proto";
 
 option (scalapb.options) = {
   collection_type: "Set"
-}
+};
 
 message CollTest {
     // Will generate Set[Int] due to file-level option.


### PR DESCRIPTION
Thanks for maintaining this project! 
Here's a small doc improvement to aid those that might directly copy the example. Without the `;`, it'll fail with `Expected ";".`